### PR TITLE
devicemanager plugin belongs to systemsplugins, not to extensions

### DIFF
--- a/meta-satdreamgr/recipes-satdreamgr/enigma2-plugins/enigma2-plugin-systemplugins-devicemanager.bb
+++ b/meta-satdreamgr/recipes-satdreamgr/enigma2-plugins/enigma2-plugin-systemplugins-devicemanager.bb
@@ -15,7 +15,3 @@ PV = "2+git${SRCPV}"
 PKGV = "2+git${GITPKGV}"
 
 inherit distutils-openplugins
-
-RPROVIDES_${PN} += "enigma2-plugin-systemplugins-devicemanager"
-RREPLACES_${PN} += "enigma2-plugin-systemplugins-devicemanager"
-RCONFLICTS_${PN} += "enigma2-plugin-systemplugins-devicemanager"

--- a/meta-satdreamgr/recipes-satdreamgr/enigma2-plugins/enigma2-plugin-systemplugins-devicemanager.bb
+++ b/meta-satdreamgr/recipes-satdreamgr/enigma2-plugins/enigma2-plugin-systemplugins-devicemanager.bb
@@ -16,6 +16,6 @@ PKGV = "2+git${GITPKGV}"
 
 inherit distutils-openplugins
 
-RPROVIDES_${PN} += "enigma2-plugin-extensions-devicemanager"
-RREPLACES_${PN} += "enigma2-plugin-extensions-devicemanager"
-RCONFLICTS_${PN} += "enigma2-plugin-extensions-devicemanager"
+RPROVIDES_${PN} += "enigma2-plugin-systemplugins-devicemanager"
+RREPLACES_${PN} += "enigma2-plugin-systemplugins-devicemanager"
+RCONFLICTS_${PN} += "enigma2-plugin-systemplugins-devicemanager"

--- a/meta-satdreamgr/recipes-satdreamgr/satdreamgr/satdreamgr-image.bb
+++ b/meta-satdreamgr/recipes-satdreamgr/satdreamgr/satdreamgr-image.bb
@@ -19,7 +19,6 @@ IMAGE_INSTALL += " \
 	${@bb.utils.contains("MACHINE_FEATURES", "blindscan-dvbs", "enigma2-plugin-systemplugins-blindscan" , "", d)} \
 	dabstreamer \
 	enigma2-plugin-extensions-backupsuite \
-	enigma2-plugin-extensions-devicemanager \
 	enigma2-plugin-extensions-epgimport \
 	enigma2-plugin-extensions-foreca \
 	enigma2-plugin-extensions-greeknetradio \
@@ -28,6 +27,7 @@ IMAGE_INSTALL += " \
 	enigma2-plugin-extensions-xmltvimport-greekepg \
 	enigma2-plugin-extensions-youtube \
 	enigma2-plugin-skins-satdreamgr-hd-transpba \
+	enigma2-plugin-systemplugins-devicemanager \
 	enigma2-plugin-systemplugins-mphelp \
 	glibc-gconv-iso8859-7 \
 	glibc-gconv-utf-16 \


### PR DESCRIPTION
If this is not how it's supposed to be (e.g. I have misunderstood something) please explain.